### PR TITLE
remove the old id from the cache

### DIFF
--- a/src/rdkafka_metadata_cache.c
+++ b/src/rdkafka_metadata_cache.c
@@ -379,8 +379,9 @@ static struct rd_kafka_metadata_cache_entry *rd_kafka_metadata_cache_insert(
                 /* If topic id isn't zero insert cache entry into this tree */
                 old_by_id = RD_AVL_INSERT(&rk->rk_metadata_cache.rkmc_avl_by_id,
                                           rkmce, rkmce_avlnode_by_id);
-        } else if (old && !RD_KAFKA_UUID_IS_ZERO(
-                              old->rkmce_metadata_internal_topic.topic_id)) {
+        }
+        if (old && !RD_KAFKA_UUID_IS_ZERO(
+                old->rkmce_metadata_internal_topic.topic_id)) {
                 /* If it had a topic id, remove it from the tree */
                 RD_AVL_REMOVE_ELM(&rk->rk_metadata_cache.rkmc_avl_by_id, old);
         }


### PR DESCRIPTION
Pulls in https://github.com/confluentinc/librdkafka/pull/4864 to attempt to fix a segfault that occurs when a topic gets recreated.

See https://github.com/confluentinc/librdkafka/issues/4778 and https://github.com/MaterializeInc/database-issues/issues/8823#issuecomment-2531576295